### PR TITLE
maximum concurrent stream is defined only by the local settings

### DIFF
--- a/lib/protocol/http2/connection.rb
+++ b/lib/protocol/http2/connection.rb
@@ -77,7 +77,7 @@ module Protocol
 			end
 			
 			def maximum_concurrent_streams
-				[@local_settings.maximum_concurrent_streams, @remote_settings.maximum_concurrent_streams].min
+				@local_settings.maximum_concurrent_streams
 			end
 			
 			attr :framer


### PR DESCRIPTION
### Types of Changes

Bug fix. Resolves #8
