### PR TITLE
Add missing require in version test

### DIFF
--- a/spec/protocol/http2_spec.rb
+++ b/spec/protocol/http2_spec.rb
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require 'protocol/http2/version'
+
 RSpec.describe Protocol::HTTP2 do
 	it "has a version number" do
 		expect(Protocol::HTTP2::VERSION).not_to be nil


### PR DESCRIPTION
This mirrors the corresponding change in `protocol-http1`: https://github.com/socketry/protocol-http1/commit/a0aa7a09956c1e411b97c66b9c5ac46d7741e0ce