### PR TITLE
Ensure wire always contains a full H/2 frame

### DIFF
--- a/lib/protocol/http2/frame.rb
+++ b/lib/protocol/http2/frame.rb
@@ -146,7 +146,7 @@ module Protocol
 			end
 			
 			def read_header(stream)
-				if buffer = stream.read(9) and buffer.bytesize == 9
+				if buffer = stream.peek(9) and buffer.bytesize == 9
 					@length, @type, @flags, @stream_id = Frame.parse_header(buffer)
 					# puts "read_header: #{@length} #{@type} #{@flags} #{@stream_id}"
 				else
@@ -155,8 +155,9 @@ module Protocol
 			end
 			
 			def read_payload(stream)
-				if payload = stream.read(@length) and payload.bytesize == @length
-					@payload = payload
+				length_with_header = 9 + @length
+				if full_frame = stream.read(length_with_header) and full_frame.bytesize == length_with_header
+					@payload = full_frame[9..]
 				else
 					raise EOFError, "Could not read frame payload!"
 				end

--- a/lib/protocol/http2/framer.rb
+++ b/lib/protocol/http2/framer.rb
@@ -3,6 +3,9 @@
 # Released under the MIT License.
 # Copyright, 2019-2023, by Samuel Williams.
 
+
+require "async-io"
+
 require_relative 'error'
 
 require_relative 'data_frame'
@@ -15,97 +18,99 @@ require_relative 'ping_frame'
 require_relative 'goaway_frame'
 require_relative 'window_update_frame'
 require_relative 'continuation_frame'
-require 'async/io'
-require 'async/io/stream'
 
 module Protocol
-  module HTTP2
-    # HTTP/2 frame type mapping as defined by the spec
-    FRAMES = [
-      DataFrame,
-      HeadersFrame,
-      PriorityFrame,
-      ResetStreamFrame,
-      SettingsFrame,
-      PushPromiseFrame,
-      PingFrame,
-      GoawayFrame,
-      WindowUpdateFrame,
-      ContinuationFrame
-    ].freeze
-
-    # Default connection "fast-fail" preamble string as defined by the spec.
-    CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
-
-    class Framer
-      def initialize(stream, frames = FRAMES)
-        @stream = case stream
-                  when Async::IO::Stream
-                    stream
-                  else
-                    Async::IO::Stream.new(stream)
-                  end
-        @frames = frames
-      end
-
-      def close
-        @stream.close
-      end
-
-      def closed?
-        @stream.closed?
-      end
-
-      def write_connection_preface
-        @stream.write(CONNECTION_PREFACE)
-      end
-
-      def read_connection_preface
-        string = @stream.read(CONNECTION_PREFACE.bytesize)
-
-        raise HandshakeError, "Invalid connection preface: #{string.inspect}" unless string == CONNECTION_PREFACE
-
-        string
-      end
-
-      # @return [Frame] the frame that has been read from the underlying IO.
-      # @raise if the underlying IO fails for some reason.
-      def read_frame(maximum_frame_size = MAXIMUM_ALLOWED_FRAME_SIZE)
-        # Read the header:
-        length, type, flags, stream_id = read_header
-
-        # Async.logger.debug(self) {"read_frame: length=#{length} type=#{type} flags=#{flags} stream_id=#{stream_id} -> klass=#{@frames[type].inspect}"}
-
-        # Allocate the frame:
-        klass = @frames[type] || Frame
-        frame = klass.new(stream_id, flags, type, length)
-
-        # Read the payload:
-        frame.read(@stream, maximum_frame_size)
-
-        # Async.logger.debug(self, name: "read") {frame.inspect}
-
-        frame
-      end
-
-      def write_frame(frame)
-        # Async.logger.debug(self, name: "write") {frame.inspect}
-
-        frame.write(@stream)
-
-        # Don't call @stream.flush here because it can cause significant contention if there is a semaphore around this method.
-        # @stream.flush
-
-        frame
-      end
-
-      def read_header
-        if (buffer = @stream.peek(9)) && (buffer.bytesize == 9)
-          return Frame.parse_header(buffer)
-        end
-
-        raise EOFError, "Could not read frame header! buffer: #{buffer.size}"
-      end
-    end
-  end
+	module HTTP2
+		# HTTP/2 frame type mapping as defined by the spec
+		FRAMES = [
+			DataFrame,
+			HeadersFrame,
+			PriorityFrame,
+			ResetStreamFrame,
+			SettingsFrame,
+			PushPromiseFrame,
+			PingFrame,
+			GoawayFrame,
+			WindowUpdateFrame,
+			ContinuationFrame,
+		].freeze
+		
+		# Default connection "fast-fail" preamble string as defined by the spec.
+		CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".freeze
+		
+		class Framer
+			def initialize(stream, frames = FRAMES)
+			 @stream = case stream
+					when Async::IO::Stream
+						stream
+					else
+						Async::IO::Stream.new(stream)
+					end
+				@frames = frames
+			end
+			
+			def close
+				@stream.close
+			end
+			
+			def closed?
+				@stream.closed?
+			end
+			
+			def write_connection_preface
+				@stream.write(CONNECTION_PREFACE)
+			end
+			
+			def read_connection_preface
+				string = @stream.read(CONNECTION_PREFACE.bytesize)
+				
+				unless string == CONNECTION_PREFACE
+					raise HandshakeError, "Invalid connection preface: #{string.inspect}"
+				end
+				
+				return string
+			end
+			
+			# @return [Frame] the frame that has been read from the underlying IO.
+			# @raise if the underlying IO fails for some reason.
+			def read_frame(maximum_frame_size = MAXIMUM_ALLOWED_FRAME_SIZE)
+				# Read the header:
+				length, type, flags, stream_id = read_header
+				
+				# Async.logger.debug(self) {"read_frame: length=#{length} type=#{type} flags=#{flags} stream_id=#{stream_id} -> klass=#{@frames[type].inspect}"}
+				
+				# Allocate the frame:
+				klass = @frames[type] || Frame
+				frame = klass.new(stream_id, flags, type, length)
+				
+				# Read the payload:
+				frame.read(@stream, maximum_frame_size)
+				
+				# Async.logger.debug(self, name: "read") {frame.inspect}
+				
+				return frame
+			end
+			
+			def write_frame(frame)
+				# Async.logger.debug(self, name: "write") {frame.inspect}
+				
+				frame.write(@stream)
+				
+				# Don't call @stream.flush here because it can cause significant contention if there is a semaphore around this method.
+				# @stream.flush
+				
+				return frame
+			end
+			
+			def read_header
+				if buffer = @stream.peek(9)
+					if buffer.bytesize == 9
+						return Frame.parse_header(buffer)
+					end
+				end
+				
+				raise EOFError, "Could not read frame header!"
+			end
+		end
+	end
 end

--- a/lib/protocol/http2/framer.rb
+++ b/lib/protocol/http2/framer.rb
@@ -16,94 +16,92 @@ require_relative 'goaway_frame'
 require_relative 'window_update_frame'
 require_relative 'continuation_frame'
 require 'async/io'
+require 'async/io/stream'
 
 module Protocol
-	module HTTP2
-		# HTTP/2 frame type mapping as defined by the spec
-		FRAMES = [
-			DataFrame,
-			HeadersFrame,
-			PriorityFrame,
-			ResetStreamFrame,
-			SettingsFrame,
-			PushPromiseFrame,
-			PingFrame,
-			GoawayFrame,
-			WindowUpdateFrame,
-			ContinuationFrame,
-		].freeze
-		
-		# Default connection "fast-fail" preamble string as defined by the spec.
-		CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".freeze
-		
-		class Framer
-			def initialize(stream, frames = FRAMES)
-				@stream = Async::IO::Stream.new(stream)
-				@frames = frames
-			end
-			
-			def close
-				@stream.close
-			end
-			
-			def closed?
-				@stream.closed?
-			end
-			
-			def write_connection_preface
-				@stream.write(CONNECTION_PREFACE)
-			end
-			
-			def read_connection_preface
-				string = @stream.read(CONNECTION_PREFACE.bytesize)
-				
-				unless string == CONNECTION_PREFACE
-					raise HandshakeError, "Invalid connection preface: #{string.inspect}"
-				end
-				
-				return string
-			end
-			
-			# @return [Frame] the frame that has been read from the underlying IO.
-			# @raise if the underlying IO fails for some reason.
-			def read_frame(maximum_frame_size = MAXIMUM_ALLOWED_FRAME_SIZE)
-				# Read the header:
-				length, type, flags, stream_id = read_header
-				
-				# Async.logger.debug(self) {"read_frame: length=#{length} type=#{type} flags=#{flags} stream_id=#{stream_id} -> klass=#{@frames[type].inspect}"}
-				
-				# Allocate the frame:
-				klass = @frames[type] || Frame
-				frame = klass.new(stream_id, flags, type, length)
-				
-				# Read the payload:
-				frame.read(@stream, maximum_frame_size)
-				
-				# Async.logger.debug(self, name: "read") {frame.inspect}
-				
-				return frame
-			end
-			
-			def write_frame(frame)
-				# Async.logger.debug(self, name: "write") {frame.inspect}
-				
-				frame.write(@stream)
-				
-				# Don't call @stream.flush here because it can cause significant contention if there is a semaphore around this method.
-				# @stream.flush
-				
-				return frame
-			end
-			
-			def read_header
-				if buffer = @stream.peek(9)
-					if buffer.bytesize == 9
-						return Frame.parse_header(buffer)
-					end
-				end
-				
-				raise EOFError, "Could not read frame header!"
-			end
-		end
-	end
+  module HTTP2
+    # HTTP/2 frame type mapping as defined by the spec
+    FRAMES = [
+      DataFrame,
+      HeadersFrame,
+      PriorityFrame,
+      ResetStreamFrame,
+      SettingsFrame,
+      PushPromiseFrame,
+      PingFrame,
+      GoawayFrame,
+      WindowUpdateFrame,
+      ContinuationFrame
+    ].freeze
+
+    # Default connection "fast-fail" preamble string as defined by the spec.
+    CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+    class Framer
+      def initialize(stream, frames = FRAMES)
+        @stream = Async::IO::Stream.new(stream)
+        puts 'HSDFILSJDFLIJSLDF'
+        @frames = frames
+      end
+
+      def close
+        @stream.close
+      end
+
+      def closed?
+        @stream.closed?
+      end
+
+      def write_connection_preface
+        @stream.write(CONNECTION_PREFACE)
+      end
+
+      def read_connection_preface
+        string = @stream.read(CONNECTION_PREFACE.bytesize)
+
+        raise HandshakeError, "Invalid connection preface: #{string.inspect}" unless string == CONNECTION_PREFACE
+
+        string
+      end
+
+      # @return [Frame] the frame that has been read from the underlying IO.
+      # @raise if the underlying IO fails for some reason.
+      def read_frame(maximum_frame_size = MAXIMUM_ALLOWED_FRAME_SIZE)
+        # Read the header:
+        length, type, flags, stream_id = read_header
+
+        # Async.logger.debug(self) {"read_frame: length=#{length} type=#{type} flags=#{flags} stream_id=#{stream_id} -> klass=#{@frames[type].inspect}"}
+
+        # Allocate the frame:
+        klass = @frames[type] || Frame
+        frame = klass.new(stream_id, flags, type, length)
+
+        # Read the payload:
+        frame.read(@stream, maximum_frame_size)
+
+        # Async.logger.debug(self, name: "read") {frame.inspect}
+
+        frame
+      end
+
+      def write_frame(frame)
+        # Async.logger.debug(self, name: "write") {frame.inspect}
+
+        frame.write(@stream)
+
+        # Don't call @stream.flush here because it can cause significant contention if there is a semaphore around this method.
+        # @stream.flush
+
+        frame
+      end
+
+      def read_header
+        if (buffer = @stream.peek(9)) && (buffer.bytesize == 9)
+          return Frame.parse_header(buffer)
+        end
+
+        raise EOFError, 'Could not read frame header!'
+      end
+    end
+  end
 end

--- a/lib/protocol/http2/framer.rb
+++ b/lib/protocol/http2/framer.rb
@@ -4,7 +4,7 @@
 # Copyright, 2019-2023, by Samuel Williams.
 
 
-require "async-io"
+require "async/io/stream"
 
 require_relative 'error'
 

--- a/lib/protocol/http2/framer.rb
+++ b/lib/protocol/http2/framer.rb
@@ -95,7 +95,7 @@ module Protocol
 			end
 			
 			def read_header
-				if buffer = @stream.read(9)
+				if buffer = @stream.peek(9)
 					if buffer.bytesize == 9
 						return Frame.parse_header(buffer)
 					end

--- a/lib/protocol/http2/framer.rb
+++ b/lib/protocol/http2/framer.rb
@@ -39,8 +39,12 @@ module Protocol
 
     class Framer
       def initialize(stream, frames = FRAMES)
-        @stream = Async::IO::Stream.new(stream)
-        puts 'HSDFILSJDFLIJSLDF'
+        @stream = case stream
+                  when Async::IO::Stream
+                    stream
+                  else
+                    Async::IO::Stream.new(stream)
+                  end
         @frames = frames
       end
 
@@ -100,7 +104,7 @@ module Protocol
           return Frame.parse_header(buffer)
         end
 
-        raise EOFError, 'Could not read frame header!'
+        raise EOFError, "Could not read frame header! buffer: #{buffer.size}"
       end
     end
   end

--- a/lib/protocol/http2/framer.rb
+++ b/lib/protocol/http2/framer.rb
@@ -15,6 +15,7 @@ require_relative 'ping_frame'
 require_relative 'goaway_frame'
 require_relative 'window_update_frame'
 require_relative 'continuation_frame'
+require 'async/io'
 
 module Protocol
 	module HTTP2
@@ -37,7 +38,7 @@ module Protocol
 		
 		class Framer
 			def initialize(stream, frames = FRAMES)
-				@stream = stream
+				@stream = Async::IO::Stream.new(stream)
 				@frames = frames
 			end
 			

--- a/protocol-http2.gemspec
+++ b/protocol-http2.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 2.7.6"
 	
+	spec.add_dependency "async-io", "~> 1.37"
 	spec.add_dependency "protocol-hpack", "~> 1.4"
 	spec.add_dependency "protocol-http", "~> 0.18"
 end


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->
Follow-up to https://github.com/socketry/async-io/pull/72 to fix https://github.com/socketry/protocol-http2/issues/14
Updates `read_header` to use `Stream#peek` instead of `Stream#read. We maintain the invariant that the read buffer / wire is always frame-aligned.  Instead of reading data off the wire when reading the header for an H/2 frame, we just peek the header and then read the full frame.


## Types of Changes
<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
