### PR TITLE
Fix `maximum_connection_streams` -> `@remote_settings`.

### DIFF
--- a/lib/protocol/http2/connection.rb
+++ b/lib/protocol/http2/connection.rb
@@ -62,8 +62,9 @@ module Protocol
 				@remote_settings.maximum_frame_size
 			end
 			
+			# The maximum number of concurrent streams that this connection can initiate:
 			def maximum_concurrent_streams
-				@local_settings.maximum_concurrent_streams
+				@remote_settings.maximum_concurrent_streams
 			end
 			
 			attr :framer
@@ -389,7 +390,8 @@ module Protocol
 						raise ProtocolError, "Invalid stream id: #{stream_id} <= #{@remote_stream_id}!"
 					end
 					
-					if @streams.size < self.maximum_concurrent_streams
+					# We need to validate that we have less streams than the specified maximum:
+					if @streams.size < @local_settings.maximum_concurrent_streams
 						stream = accept_stream(stream_id)
 						@remote_stream_id = stream_id
 						


### PR DESCRIPTION
`Connection#maximum_concurrent_streams` was using `@local_settings`, but it is used for the concurrency limit in `async-http`. This is simply the wrong value to use, it should be using the `@remote_settings`.

Fixes <https://github.com/socketry/async-http/issues/161>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
