### PR TITLE
Ensure wire always contains a full H/2 frame (#15)

### DIFF
--- a/lib/protocol/http2/frame.rb
+++ b/lib/protocol/http2/frame.rb
@@ -146,7 +146,7 @@ module Protocol
 			end
 			
 			def read_header(stream)
-				if buffer = stream.read(9) and buffer.bytesize == 9
+				if buffer = stream.peek(9) and buffer.bytesize == 9
 					@length, @type, @flags, @stream_id = Frame.parse_header(buffer)
 					# puts "read_header: #{@length} #{@type} #{@flags} #{@stream_id}"
 				else
@@ -155,8 +155,9 @@ module Protocol
 			end
 			
 			def read_payload(stream)
-				if payload = stream.read(@length) and payload.bytesize == @length
-					@payload = payload
+				length_with_header = 9 + @length
+				if full_frame = stream.read(length_with_header) and full_frame.bytesize == length_with_header
+					@payload = full_frame[9..]
 				else
 					raise EOFError, "Could not read frame payload!"
 				end

--- a/lib/protocol/http2/framer.rb
+++ b/lib/protocol/http2/framer.rb
@@ -3,6 +3,9 @@
 # Released under the MIT License.
 # Copyright, 2019-2024, by Samuel Williams.
 
+
+require "async/io/stream"
+
 require_relative 'error'
 
 require_relative 'data_frame'
@@ -37,7 +40,12 @@ module Protocol
 		
 		class Framer
 			def initialize(stream, frames = FRAMES)
-				@stream = stream
+			 @stream = case stream
+					when Async::IO::Stream
+						stream
+					else
+						Async::IO::Stream.new(stream)
+					end
 				@frames = frames
 			end
 			
@@ -99,7 +107,7 @@ module Protocol
 			end
 			
 			def read_header
-				if buffer = @stream.read(9)
+				if buffer = @stream.peek(9)
 					if buffer.bytesize == 9
 						return Frame.parse_header(buffer)
 					end

--- a/protocol-http2.gemspec
+++ b/protocol-http2.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.1"
 	
+	spec.add_dependency "async-io", "~> 1.37"
 	spec.add_dependency "protocol-hpack", "~> 1.4"
 	spec.add_dependency "protocol-http", "~> 0.18"
 end


### PR DESCRIPTION
Use atomic operations for reading frames.

If reading the payload of a frame times out (after reading the header), it puts the stream in an odd state.

Fixes <https://github.com/socketry/protocol-http2/issues/14>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
