### PR TITLE
Reduce number of window update frames sent.

### DIFF
--- a/lib/protocol/http2/connection.rb
+++ b/lib/protocol/http2/connection.rb
@@ -41,7 +41,7 @@ module Protocol
 				@decoder = HPACK::Context.new
 				@encoder = HPACK::Context.new
 				
-				@local_window = LocalWindow.new()
+				@local_window = LocalWindow.new
 				@remote_window = Window.new
 			end
 			

--- a/lib/protocol/http2/flow_controlled.rb
+++ b/lib/protocol/http2/flow_controlled.rb
@@ -70,15 +70,11 @@ module Protocol
 			def receive_window_update(frame)
 				amount = frame.unpack
 				
-				# Async.logger.info(self) {"expanding remote_window=#{@remote_window} by #{amount}"}
-				
 				if amount != 0
 					@remote_window.expand(amount)
 				else
 					raise ProtocolError, "Invalid window size increment: #{amount}!"
 				end
-				
-				# puts "expanded remote_window=#{@remote_window} by #{amount}"
 			end
 			
 			# The window has been expanded by the given amount.

--- a/test/protocol/http2/window.rb
+++ b/test/protocol/http2/window.rb
@@ -4,6 +4,7 @@
 # Copyright, 2019-2024, by Samuel Williams.
 
 require "protocol/http2/connection_context"
+require "json"
 
 describe Protocol::HTTP2::Window do
 	let(:window) {subject.new}
@@ -53,6 +54,31 @@ describe Protocol::HTTP2::LocalWindow do
 		it "can consume available capacity" do
 			window.consume(window.available)
 			expect(window.wanted).to be == 200
+		end
+		
+		it "is not limited if the half the desired capacity is available" do
+			expect(window).not.to be(:limited?)
+			
+			# Consume the entire window:
+			window.consume(window.available)
+			
+			expect(window).to be(:limited?)
+			
+			# Expand the window by at least half the desired capacity:
+			window.expand(window.desired / 2)
+			
+			expect(window).not.to be(:limited?)
+		end
+	end
+	
+	with "#limited?" do
+		it "becomes limited after half the capacity is consumed" do
+			expect(window).not.to be(:limited?)
+			
+			# Consume a little more than half:
+			window.consume(window.capacity / 2 + 2)
+			
+			expect(window).to be(:limited?)
 		end
 	end
 end


### PR DESCRIPTION
I identified some performance problems due to the excessive number of window updates being generated. Change the local window to only become limited when it's at half the desired availability to avoid sending a window update on every read.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
