### PR TITLE
Bump `protocol-http` version in gemspec

### DIFF
--- a/protocol-http2.gemspec
+++ b/protocol-http2.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 3.1"
 	
 	spec.add_dependency "protocol-hpack", "~> 1.4"
-	spec.add_dependency "protocol-http", "~> 0.18"
+	spec.add_dependency "protocol-http", "~> 0.47"
 end


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

I believe `protocol/http/header/priority` was added in `0.47.0` of `protocol-http`. This gem started using it [here](https://github.com/socketry/protocol-http2/blob/02df9acb1a198d5ede7212bfa698c723b0f557bd/lib/protocol/http2/connection.rb#L11), but the minimum version of `protocol-http` in the gemspec is `0.18`. This PR bumps the version to `0.47` to ensure that `protocol/http/header/priority` is available.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
