### PR TITLE
Add stream error messages.

### DIFF
--- a/lib/protocol/http2/error.rb
+++ b/lib/protocol/http2/error.rb
@@ -50,6 +50,30 @@ module Protocol
 			
 			# The endpoint requires that HTTP/1.1 be used instead of HTTP/2.
 			HTTP_1_1_REQUIRED = 0xD
+			
+			MESSAGES = {
+				NO_ERROR => "No error.",
+				PROTOCOL_ERROR => "Protocol error!",
+				INTERNAL_ERROR => "Internal error!",
+				FLOW_CONTROL_ERROR => "Flow control error!",
+				SETTINGS_TIMEOUT => "Settings timeout!",
+				STREAM_CLOSED => "Stream closed!",
+				FRAME_SIZE_ERROR => "Frame size error!",
+				REFUSED_STREAM => "Stream refused.",
+				CANCEL => "Stream cancelled.",
+				COMPRESSION_ERROR => "Compression error!",
+				CONNECT_ERROR => "Connect error!",
+				ENHANCE_YOUR_CALM => "Enhance your calm!",
+				INADEQUATE_SECURITY => "Inadequate security!",
+				HTTP_1_1_REQUIRED => "HTTP/1.1 required.",
+			}
+			
+			def self.message_for(code)
+				return MESSAGES.fetch(code) do
+					# Unknown error codes are allowed by the protocol, but don't have a static message.
+					"Unknown code: #{code}!"
+				end
+			end
 		end
 		
 		# Raised if connection header is missing or invalid indicating that
@@ -76,30 +100,8 @@ module Protocol
 		
 		# Represents an error specific to stream operations.
 		class StreamError < ProtocolError
-			MESSAGES = {
-				Error::NO_ERROR => "No error.",
-				Error::PROTOCOL_ERROR => "Protocol error!",
-				Error::INTERNAL_ERROR => "Internal error!",
-				Error::FLOW_CONTROL_ERROR => "Flow control error!",
-				Error::SETTINGS_TIMEOUT => "Settings timeout!",
-				Error::STREAM_CLOSED => "Stream closed!",
-				Error::FRAME_SIZE_ERROR => "Frame size error!",
-				Error::REFUSED_STREAM => "Stream refused.",
-				Error::CANCEL => "Stream cancelled.",
-				Error::COMPRESSION_ERROR => "Compression error!",
-				Error::CONNECT_ERROR => "Connect error!",
-				Error::ENHANCE_YOUR_CALM => "Enhance your calm!",
-				Error::INADEQUATE_SECURITY => "Inadequate security!",
-				Error::HTTP_1_1_REQUIRED => "HTTP/1.1 required.",
-			}
-			
 			def self.for(code)
-				message = MESSAGES.fetch(code) do
-					# Unknown error codes are allowed by the protocol, but don't have a static message.
-					"Unknown code: #{code}!"
-				end
-				
-				return self.new(message, code)
+				return self.new(Error.message_for(code), code)
 			end
 		end
 		

--- a/lib/protocol/http2/error.rb
+++ b/lib/protocol/http2/error.rb
@@ -86,6 +86,10 @@ module Protocol
 		# which signals termination of the current connection. You *cannot*
 		# recover from this exception, or any exceptions subclassed from it.
 		class ProtocolError < Error
+			def self.for(code)
+				return self.new(Error.message_for(code), code)
+			end
+			
 			# Initialize a protocol error with message and error code.
 			# @parameter message [String] The error message.
 			# @parameter code [Integer] The HTTP/2 error code.
@@ -100,9 +104,6 @@ module Protocol
 		
 		# Represents an error specific to stream operations.
 		class StreamError < ProtocolError
-			def self.for(code)
-				return self.new(Error.message_for(code), code)
-			end
 		end
 		
 		# Represents an error for operations on closed streams.

--- a/lib/protocol/http2/error.rb
+++ b/lib/protocol/http2/error.rb
@@ -76,6 +76,31 @@ module Protocol
 		
 		# Represents an error specific to stream operations.
 		class StreamError < ProtocolError
+			MESSAGES = {
+				Error::NO_ERROR => "No error.",
+				Error::PROTOCOL_ERROR => "Protocol error!",
+				Error::INTERNAL_ERROR => "Internal error!",
+				Error::FLOW_CONTROL_ERROR => "Flow control error!",
+				Error::SETTINGS_TIMEOUT => "Settings timeout!",
+				Error::STREAM_CLOSED => "Stream closed!",
+				Error::FRAME_SIZE_ERROR => "Frame size error!",
+				Error::REFUSED_STREAM => "Stream refused.",
+				Error::CANCEL => "Stream cancelled.",
+				Error::COMPRESSION_ERROR => "Compression error!",
+				Error::CONNECT_ERROR => "Connect error!",
+				Error::ENHANCE_YOUR_CALM => "Enhance your calm!",
+				Error::INADEQUATE_SECURITY => "Inadequate security!",
+				Error::HTTP_1_1_REQUIRED => "HTTP/1.1 required.",
+			}
+			
+			def self.for(code)
+				message = MESSAGES.fetch(code) do
+					# Unknown error codes are allowed by the protocol, but don't have a static message.
+					"Unknown code: #{code}!"
+				end
+				
+				return self.new(message, code)
+			end
 		end
 		
 		# Represents an error for operations on closed streams.

--- a/lib/protocol/http2/error.rb
+++ b/lib/protocol/http2/error.rb
@@ -68,6 +68,9 @@ module Protocol
 				HTTP_1_1_REQUIRED => "HTTP/1.1 required.",
 			}
 			
+			# Get the message for a given HTTP/2 error code.
+			# @parameter code [Integer] The HTTP/2 error code.
+			# @returns [String] The error message.
 			def self.message_for(code)
 				return MESSAGES.fetch(code) do
 					# Unknown error codes are allowed by the protocol, but don't have a static message.
@@ -86,6 +89,9 @@ module Protocol
 		# which signals termination of the current connection. You *cannot*
 		# recover from this exception, or any exceptions subclassed from it.
 		class ProtocolError < Error
+			# Build a protocol error for a given HTTP/2 error code.
+			# @parameter code [Integer] The HTTP/2 error code.
+			# @returns [ProtocolError] The protocol error.
 			def self.for(code)
 				return self.new(Error.message_for(code), code)
 			end

--- a/lib/protocol/http2/stream.rb
+++ b/lib/protocol/http2/stream.rb
@@ -253,7 +253,7 @@ module Protocol
 					if error_code == REFUSED_STREAM
 						error = ::Protocol::HTTP::RefusedError.new("Stream refused.")
 					else
-						error = StreamError.new("Stream closed!", error_code)
+						error = StreamError.for(error_code)
 					end
 				end
 				

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Improve `StreamError` messages for HTTP/2 stream reset error codes.
+
 ## v0.26.0
 
   - On RST\_STREAM with REFUSED\_STREAM, close the stream with `Protocol::HTTP::RefusedError` instead of `StreamError`.

--- a/test/protocol/http2/error.rb
+++ b/test/protocol/http2/error.rb
@@ -17,6 +17,18 @@ describe Protocol::HTTP2::Error do
 	end
 end
 
+describe Protocol::HTTP2::ProtocolError do
+	with ".for" do
+		it "builds a protocol error for a known error code" do
+			error = subject.for(subject::PROTOCOL_ERROR)
+			
+			expect(error).to be_a(subject)
+			expect(error.message).to be == "Protocol error!"
+			expect(error.code).to be == subject::PROTOCOL_ERROR
+		end
+	end
+end
+
 describe Protocol::HTTP2::StreamError do
 	with ".for" do
 		it "builds a stream error for a known error code" do

--- a/test/protocol/http2/error.rb
+++ b/test/protocol/http2/error.rb
@@ -5,6 +5,26 @@
 
 require "protocol/http2/error"
 
+describe Protocol::HTTP2::StreamError do
+	with ".for" do
+		it "builds a stream error for a known error code" do
+			error = subject.for(Protocol::HTTP2::Error::CANCEL)
+			
+			expect(error).to be_a(subject)
+			expect(error.message).to be == "Stream cancelled."
+			expect(error.code).to be == Protocol::HTTP2::Error::CANCEL
+		end
+		
+		it "builds a stream error for an unknown error code" do
+			error = subject.for(99)
+			
+			expect(error).to be_a(subject)
+			expect(error.message).to be == "Unknown code: 99!"
+			expect(error.code).to be == 99
+		end
+	end
+end
+
 describe Protocol::HTTP2::HeaderError do
 	let(:error) {subject.new("Invalid header key")}
 	

--- a/test/protocol/http2/error.rb
+++ b/test/protocol/http2/error.rb
@@ -5,6 +5,18 @@
 
 require "protocol/http2/error"
 
+describe Protocol::HTTP2::Error do
+	with ".message_for" do
+		it "returns a static message for a known error code" do
+			expect(subject.message_for(subject::CANCEL)).to be == "Stream cancelled."
+		end
+		
+		it "returns a fallback message for an unknown error code" do
+			expect(subject.message_for(99)).to be == "Unknown code: 99!"
+		end
+	end
+end
+
 describe Protocol::HTTP2::StreamError do
 	with ".for" do
 		it "builds a stream error for a known error code" do


### PR DESCRIPTION
## Summary

- Add `Protocol::HTTP2::StreamError.for(code)` with static messages for known HTTP/2 error codes.
- Use the factory when closing streams due to non-refused `RST_STREAM` errors.
- Add tests for known and unknown stream error codes.

## Testing

- `ruby -Ilib -Itest -e 'require "protocol/http2/error"; error = Protocol::HTTP2::StreamError.for(Protocol::HTTP2::Error::CANCEL); abort error.message unless error.message == "Stream cancelled."; abort error.code.inspect unless error.code == 8; unknown = Protocol::HTTP2::StreamError.for(99); abort unknown.message unless unknown.message == "Unknown code: 99!"; abort unknown.code.inspect unless unknown.code == 99'`

## Notes

- `bundle exec sus ...` is currently blocked locally because this checkout is missing several locked gem versions.