### PR TITLE
Mask GOAWAY last stream id

### DIFF
--- a/lib/protocol/http2/goaway_frame.rb
+++ b/lib/protocol/http2/goaway_frame.rb
@@ -33,6 +33,7 @@ module Protocol
 				data = super
 				
 				last_stream_id, error_code = data.unpack(FORMAT)
+				last_stream_id &= 0x7fffffff
 				
 				return last_stream_id, error_code, data.slice(8, data.bytesize-8)
 			end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Ignore the reserved high bit when decoding GOAWAY last stream IDs.
+
 ## v0.26.1
 
   - Improve `StreamError` messages for HTTP/2 stream reset error codes.

--- a/test/protocol/http2/goaway_frame.rb
+++ b/test/protocol/http2/goaway_frame.rb
@@ -38,5 +38,11 @@ describe Protocol::HTTP2::GoawayFrame do
 			
 			expect(frame.unpack).to be == [3, 2, data]
 		end
+		
+		it "ignores the reserved high bit of the last stream id" do
+			frame.pack 0x80000003, 2, data
+			
+			expect(frame.unpack).to be == [3, 2, data]
+		end
 	end
 end


### PR DESCRIPTION
## Summary

- Mask the reserved high bit when decoding GOAWAY `last_stream_id`.
- Add a regression test for GOAWAY frames with the reserved bit set.
- Add an Unreleased release note.

## Testing

- `ruby -Ilib -e 'require "protocol/http2/goaway_frame"; frame = Protocol::HTTP2::GoawayFrame.new; frame.pack(0x80000003, 2, "debug"); last_stream_id, error_code, data = frame.unpack; abort last_stream_id.inspect unless last_stream_id == 3; abort error_code.inspect unless error_code == 2; abort data.inspect unless data == "debug"'`

Note: Full `bundle exec sus ...` remains blocked locally by missing locked gem versions in this checkout.